### PR TITLE
🔑 Provide path for GPG to verify the archive

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -35,7 +35,7 @@ asdf_yarn_install() {
     wget -q -O - "https://dl.yarnpkg.com/debian/pubkey.gpg" | GNUPGHOME="$(asdf_yarn_keyring)" gpg --import
 
     # Verify archive signature
-    GNUPGHOME="$(asdf_yarn_keyring)" gpg --verify "yarn-v${ASDF_INSTALL_VERSION}.tar.gz.asc"
+    GNUPGHOME="$(asdf_yarn_keyring)" gpg --verify "yarn-v${ASDF_INSTALL_VERSION}.tar.gz.asc" "yarn-v${ASDF_INSTALL_VERSION}.tar.gz"
 
     # Extract archive
     tar xzf "yarn-v${ASDF_INSTALL_VERSION}.tar.gz" --strip-components=1 --no-same-owner


### PR DESCRIPTION
...instead of relying on "historical behavior" that has been "strongly discouraged" in [GPG documentation](https://www.gnupg.org/documentation/manuals/gnupg/Operational-GPG-Commands.html#Operational-GPG-Commands). Thanks @Stratus3D for [identifying this issue](https://github.com/asdf-vm/asdf-plugins/pull/83#issuecomment-496519951).