### PR TITLE
🔥 Remove redundant `bin/list-bin-paths` command

### DIFF
--- a/bin/list-bin-paths
+++ b/bin/list-bin-paths
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-
-set -o nounset -o pipefail -o errexit
-IFS=$'\t\n'
-
-echo "bin"


### PR DESCRIPTION
This command emits **bin**, which:

 1. ...is the default behavior when no explicit `bin/list-bin-paths` command is present, and
 2. ...is likely to ever be the only executable path used by this plugin.

Therefore, removing this file in favor of the default behavior.