### PR TITLE
🐛 Let wget fail if there is an error

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -21,10 +21,10 @@ asdf_yarn_keyring() {
 
 asdf_yarn_download_wget() {
   # Download archive
-  wget -q "https://github.com/yarnpkg/yarn/releases/download/v${ASDF_INSTALL_VERSION}/yarn-v${ASDF_INSTALL_VERSION}.tar.gz"
+  wget "https://github.com/yarnpkg/yarn/releases/download/v${ASDF_INSTALL_VERSION}/yarn-v${ASDF_INSTALL_VERSION}.tar.gz"
 
   # Download archive signature
-  wget -q "https://github.com/yarnpkg/yarn/releases/download/v${ASDF_INSTALL_VERSION}/yarn-v${ASDF_INSTALL_VERSION}.tar.gz.asc"
+  wget "https://github.com/yarnpkg/yarn/releases/download/v${ASDF_INSTALL_VERSION}/yarn-v${ASDF_INSTALL_VERSION}.tar.gz.asc"
 
   # Download and import signing key
   wget -q -O - "https://dl.yarnpkg.com/debian/pubkey.gpg" | GNUPGHOME="$(asdf_yarn_keyring)" gpg --import


### PR DESCRIPTION
Resolves [#4](https://github.com/twuni/asdf-yarn/issues/4).

Previously, wget would silently fail with status 0 because its `-q` (quiet) flag was set. This commit removes that.