### PR TITLE
📝 Add instructions for Yarn v2.x to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,23 @@ asdf plugin-add yarn
 asdf install yarn latest
 ```
 
+## Looking for Yarn v2?
+
+In v2.x, Yarn introduced its own version manager which can only be
+configured on a per-project basis. There is no "global install" variation
+of the v2.x release line.
+
+To use Yarn v2.x in your project:
+
+ 1. Use this plugin to set the v1.x Yarn version for the project
+    (e.g: `asdf local yarn 1.22.10`).
+
+ 2. Use Yarn to set the v2.x Yarn version for the project
+    (e.g: `yarn set version 2.4.1`).
+
+After these two steps, your project will be configured to use Yarn v2.x.
+If you do not wish to opt in to v2.x, then step 1 is all you need.
+
 [1]: https://asdf-vm.com/
 [2]: https://www.openpgp.org/
 [3]: https://travis-ci.org/twuni/asdf-yarn.svg?branch=master


### PR DESCRIPTION
As recommended in https://github.com/twuni/asdf-yarn/issues/12#issuecomment-761532814.

In July 2020, the first stable release (v2.1.0) of Yarn v2.x was released. The v2.x release line includes its own version manager that operates natively on a per-project basis (vs global install). The v2.x release line still requires installation of v1.x to provide the `yarn` command needed to bootstrap the project configuration.

This changes the dynamics of how asdf works with Yarn. Rather than having this plugin provide a conflicting mechanism for Yarn version management at v2.x onward, it opts to leverage Yarn's version management for projects that opt in to v2.x. Thus, for v2.x, asdf is **complementary** to Yarn's own version management strategy rather than a *replacement* for it.

Use this plugin to make the `yarn` executable available to your project (or globally if you wish). Then, use that `yarn` executable to manage your project-specific Yarn version (if your project wishes to use v2.x).

cc @DilumAluthge @toastal 