### PR TITLE
🔧 Rename default branch to "main"

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,5 +20,5 @@ asdf install yarn latest
 
 [1]: https://asdf-vm.com/
 [2]: https://www.openpgp.org/
-[3]: https://travis-ci.org/twuni/asdf-yarn.svg?branch=master
+[3]: https://travis-ci.org/twuni/asdf-yarn.svg?branch=main
 [4]: https://travis-ci.org/twuni/asdf-yarn


### PR DESCRIPTION
See https://github.com/github/renaming.

TL;DR. "main" is just as good of a name as "master" but without the baggage. Good riddance, antiquated metaphors!