### PR TITLE
Warn and fail early when installing 1.22.6 through 1.22.9

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -86,5 +86,6 @@ asdf_yarn_install() {
 [ -z "${ASDF_INSTALL_PATH}" ] && asdf_yarn_fail "No installation directory was provided. Are you running this command via asdf? Try running 'asdf install yarn <version>'"
 [ -x "$(which wget)" -o -x "$(which curl)" ] || asdf_yarn_fail "Missing one of either of the following dependencies: wget, curl"
 [ -x "$(which tar)" -a -x "$(which gpg)" ] || asdf_yarn_fail "Missing one or more of the following dependencies: tar, gpg"
+echo "${ASDF_INSTALL_VERSION}" | grep '1\.22\.[6-9]' > /dev/null && asdf_yarn_fail 'yarn versions 1.22.6 through 1.22.9 are missing the `.asc`-signature key on Github, and thus cannot be verified. Please install a different version.'
 
 asdf_yarn_install $*

--- a/bin/list-all
+++ b/bin/list-all
@@ -3,10 +3,13 @@
 set -o nounset -o pipefail -o errexit
 IFS=$'\t\n'
 
+# Versions 1.22.6 through 1.22.9 are missing the `.asc`-signature key on Github
+# so cannot be installed with verification.
 git ls-remote --refs --tags "https://github.com/yarnpkg/yarn.git" \
 | sed -E 's|^.+refs/tags/||g' \
 | grep -E '^v' \
 | sort --version-sort \
 | sed -E 's|^v||g' \
 | grep -Ev '^0\.' \
+| grep -Ev '^1\.22\.[6-9]$' \
 | xargs


### PR DESCRIPTION
Versions 1.22.6 through 1.22.9 are missing the `.asc`-signature key on Github so cannot be installed with verification.

Since there's no way to disable verification this change simply makes those version unavailable in the `list-all` command and fails early in the `install` command.