### PR TITLE
Tidy up the output during installation

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -60,7 +60,7 @@ asdf_yarn_install() {
     asdf_yarn_download
 
     # Verify archive signature
-    GNUPGHOME="$(asdf_yarn_keyring)" gpg -q --verify "yarn-v${ASDF_INSTALL_VERSION}.tar.gz.asc" "yarn-v${ASDF_INSTALL_VERSION}.tar.gz"
+    GNUPGHOME="$(asdf_yarn_keyring)" gpg -q --verify "yarn-v${ASDF_INSTALL_VERSION}.tar.gz.asc" "yarn-v${ASDF_INSTALL_VERSION}.tar.gz" 2>/dev/null
 
     # Extract archive
     tar xzf "yarn-v${ASDF_INSTALL_VERSION}.tar.gz" --strip-components=1 --no-same-owner

--- a/bin/install
+++ b/bin/install
@@ -21,13 +21,13 @@ asdf_yarn_keyring() {
 
 asdf_yarn_download_wget() {
   # Download archive
-  wget -O "yarn-v${ASDF_INSTALL_VERSION}.tar.gz" "https://classic.yarnpkg.com/downloads/${ASDF_INSTALL_VERSION}/yarn-v${ASDF_INSTALL_VERSION}.tar.gz"
+  wget -q -O "yarn-v${ASDF_INSTALL_VERSION}.tar.gz" "https://classic.yarnpkg.com/downloads/${ASDF_INSTALL_VERSION}/yarn-v${ASDF_INSTALL_VERSION}.tar.gz"
 
   # Download archive signature
-  wget -O "yarn-v${ASDF_INSTALL_VERSION}.tar.gz.asc" "https://classic.yarnpkg.com/downloads/${ASDF_INSTALL_VERSION}/yarn-v${ASDF_INSTALL_VERSION}.tar.gz.asc"
+  wget -q -O "yarn-v${ASDF_INSTALL_VERSION}.tar.gz.asc" "https://classic.yarnpkg.com/downloads/${ASDF_INSTALL_VERSION}/yarn-v${ASDF_INSTALL_VERSION}.tar.gz.asc"
 
   # Download and import signing key
-  wget -q -O - "https://dl.yarnpkg.com/debian/pubkey.gpg" | GNUPGHOME="$(asdf_yarn_keyring)" gpg --import
+  wget -q -O - "https://dl.yarnpkg.com/debian/pubkey.gpg" | GNUPGHOME="$(asdf_yarn_keyring)" gpg -q --import
 }
 
 asdf_yarn_download_curl() {
@@ -38,7 +38,7 @@ asdf_yarn_download_curl() {
   curl -sSL -o "yarn-v${ASDF_INSTALL_VERSION}.tar.gz.asc" "https://classic.yarnpkg.com/downloads/${ASDF_INSTALL_VERSION}/yarn-v${ASDF_INSTALL_VERSION}.tar.gz.asc"
 
   # Download and import signing key
-  curl -sSL "https://dl.yarnpkg.com/debian/pubkey.gpg" | GNUPGHOME="$(asdf_yarn_keyring)" gpg --import
+  curl -sSL "https://dl.yarnpkg.com/debian/pubkey.gpg" | GNUPGHOME="$(asdf_yarn_keyring)" gpg -q --import
 }
 
 asdf_yarn_download() {
@@ -60,7 +60,7 @@ asdf_yarn_install() {
     asdf_yarn_download
 
     # Verify archive signature
-    GNUPGHOME="$(asdf_yarn_keyring)" gpg --verify "yarn-v${ASDF_INSTALL_VERSION}.tar.gz.asc" "yarn-v${ASDF_INSTALL_VERSION}.tar.gz"
+    GNUPGHOME="$(asdf_yarn_keyring)" gpg -q --verify "yarn-v${ASDF_INSTALL_VERSION}.tar.gz.asc" "yarn-v${ASDF_INSTALL_VERSION}.tar.gz"
 
     # Extract archive
     tar xzf "yarn-v${ASDF_INSTALL_VERSION}.tar.gz" --strip-components=1 --no-same-owner

--- a/bin/install
+++ b/bin/install
@@ -8,6 +8,31 @@ asdf_yarn_fail() {
   exit 1
 }
 
+asdf_yarn_progress() {
+  >&2 printf "\e[32m"
+  if [[ "$1" -gt 0 ]]; then
+    for i in $(seq 1 "$1"); do
+      >&2 printf "█"
+    done
+  fi
+  >&2 printf "\e[2m"
+  if [[ "$1" -lt 5 ]]; then
+    for i in $(seq "$1" 4); do
+      >&2 printf "█"
+    done
+  fi
+  >&2 printf "\e[0m "
+}
+
+asdf_yarn_progress_clear() {
+  >&2 printf "\b\b\b\b\b\b"
+}
+
+asdf_yarn_progress_step() {
+  asdf_yarn_progress_clear
+  asdf_yarn_progress "$@"
+}
+
 asdf_yarn_keyring() {
   local YARN_KEYRING="${ASDF_DATA_DIR:-$HOME/.asdf}/keyrings/yarn"
 
@@ -21,24 +46,24 @@ asdf_yarn_keyring() {
 
 asdf_yarn_download_wget() {
   # Download archive
-  wget -q -O "yarn-v${ASDF_INSTALL_VERSION}.tar.gz" "https://classic.yarnpkg.com/downloads/${ASDF_INSTALL_VERSION}/yarn-v${ASDF_INSTALL_VERSION}.tar.gz"
+  wget -q -O "yarn-v${ASDF_INSTALL_VERSION}.tar.gz" "https://classic.yarnpkg.com/downloads/${ASDF_INSTALL_VERSION}/yarn-v${ASDF_INSTALL_VERSION}.tar.gz" || asdf_yarn_fail 'failed to download archive'
 
   # Download archive signature
-  wget -q -O "yarn-v${ASDF_INSTALL_VERSION}.tar.gz.asc" "https://classic.yarnpkg.com/downloads/${ASDF_INSTALL_VERSION}/yarn-v${ASDF_INSTALL_VERSION}.tar.gz.asc"
+  wget -q -O "yarn-v${ASDF_INSTALL_VERSION}.tar.gz.asc" "https://classic.yarnpkg.com/downloads/${ASDF_INSTALL_VERSION}/yarn-v${ASDF_INSTALL_VERSION}.tar.gz.asc" || asdf_yarn_fail 'failed to download signature'
 
   # Download and import signing key
-  wget -q -O - "https://dl.yarnpkg.com/debian/pubkey.gpg" | GNUPGHOME="$(asdf_yarn_keyring)" gpg -q --import
+  wget -q -O - "https://dl.yarnpkg.com/debian/pubkey.gpg" | GNUPGHOME="$(asdf_yarn_keyring)" gpg -q --import || asdf_yarn_fail 'failed to download signing key'
 }
 
 asdf_yarn_download_curl() {
   # Download archive
-  curl -sSL -o "yarn-v${ASDF_INSTALL_VERSION}.tar.gz" "https://classic.yarnpkg.com/downloads/${ASDF_INSTALL_VERSION}/yarn-v${ASDF_INSTALL_VERSION}.tar.gz"
+  curl -sSL -o "yarn-v${ASDF_INSTALL_VERSION}.tar.gz" "https://classic.yarnpkg.com/downloads/${ASDF_INSTALL_VERSION}/yarn-v${ASDF_INSTALL_VERSION}.tar.gz" || asdf_yarn_fail 'failed to download archive'
 
   # Download archive signature
-  curl -sSL -o "yarn-v${ASDF_INSTALL_VERSION}.tar.gz.asc" "https://classic.yarnpkg.com/downloads/${ASDF_INSTALL_VERSION}/yarn-v${ASDF_INSTALL_VERSION}.tar.gz.asc"
+  curl -sSL -o "yarn-v${ASDF_INSTALL_VERSION}.tar.gz.asc" "https://classic.yarnpkg.com/downloads/${ASDF_INSTALL_VERSION}/yarn-v${ASDF_INSTALL_VERSION}.tar.gz.asc" || asdf_yarn_fail 'failed to download signature'
 
   # Download and import signing key
-  curl -sSL "https://dl.yarnpkg.com/debian/pubkey.gpg" | GNUPGHOME="$(asdf_yarn_keyring)" gpg -q --import
+  curl -sSL "https://dl.yarnpkg.com/debian/pubkey.gpg" | GNUPGHOME="$(asdf_yarn_keyring)" gpg -q --import || asdf_yarn_fail 'failed to download signing key'
 }
 
 asdf_yarn_download() {
@@ -52,22 +77,29 @@ asdf_yarn_download() {
 }
 
 asdf_yarn_install() {
+  >&2 printf "🧶 yarn ${ASDF_INSTALL_VERSION} "
   local ASDF_YARN_DIR="$(mktemp -d -t asdf-yarn-XXXXXXX)"
 
   (
     cd "${ASDF_YARN_DIR}"
 
+    asdf_yarn_progress 0
     asdf_yarn_download
 
+    asdf_yarn_progress_step 1
     # Verify archive signature
-    GNUPGHOME="$(asdf_yarn_keyring)" gpg -q --verify "yarn-v${ASDF_INSTALL_VERSION}.tar.gz.asc" "yarn-v${ASDF_INSTALL_VERSION}.tar.gz" 2>/dev/null
+    GNUPGHOME="$(asdf_yarn_keyring)" gpg -q --verify "yarn-v${ASDF_INSTALL_VERSION}.tar.gz.asc" "yarn-v${ASDF_INSTALL_VERSION}.tar.gz" 2>/dev/null || asdf_yarn_fail 'failed to verify signature'
 
+    asdf_yarn_progress_step 2
     # Extract archive
     tar xzf "yarn-v${ASDF_INSTALL_VERSION}.tar.gz" --strip-components=1 --no-same-owner
 
+    asdf_yarn_progress_step 3
     # Remove downloaded files
     rm -f "yarn-v${ASDF_INSTALL_VERSION}.tar.gz" "yarn-v${ASDF_INSTALL_VERSION}.tar.gz.asc"
   )
+
+  asdf_yarn_progress_step 4
 
   if [ -d "${ASDF_INSTALL_PATH}" ]; then
     # Remove existing install directory
@@ -79,6 +111,9 @@ asdf_yarn_install() {
 
   # Finish the installation
   mv "${ASDF_YARN_DIR}" "${ASDF_INSTALL_PATH}"
+
+  asdf_yarn_progress_step 5
+  echo '✅ installed!'
 }
 
 [ "${ASDF_INSTALL_TYPE}" == 'ref' ] && asdf_yarn_fail "This plugin does not support installing by ref."


### PR DESCRIPTION
Currently, the output of this plugin when installing a version is quite ugly and intimidating.

<img width="1909" alt="Screen Shot 2022-07-27 at 23 06 00" src="https://user-images.githubusercontent.com/4053794/181433287-8f54d5a6-6c59-4b4f-98c9-bc2bf8137a51.png">

In this PR, I've made that output much cleaner for humans to read.

<img width="569" alt="Screen Shot 2022-07-27 at 23 04 12" src="https://user-images.githubusercontent.com/4053794/181433274-65b5f2b6-3352-44c1-bb45-7daaf13ef3e9.png">

# Notable Changes

 1. The `-q` flag is now being passed to `wget` commands, which are the primary offenders of the bulky output.
 2. The `-q` flag is now being passed to `gpg` commands, particularly the `--verify` command, which prints a spurious warning about the key not being trusted -- we can safely ignore that because we're using a dedicated keyring for this plugin where we've pulled the signing key from a trusted official source via a secure channel.
 3. Output is now consolidated to a single line, whether successful or failed, with a curated error message upon failure and an unambiguous confirmation upon success.

# How to verify

```bash
# Install this plugin if it's not already installed
$ asdf plugin-add yarn

# Fetch the latest source and check out this PR's branch
$ (cd ~/.asdf/plugins/yarn && git fetch --all && git checkout quiet-gpg-and-wget)

# Install a real version of yarn to confirm it works as expected
$ asdf install yarn 1.22.19

# Install a non-existent version to confirm it fails as expected
$ asdf install yarn 1.3.37
```

# Potential Issues

 * If my "prettification" here is too cute or garish, I accept that. I may have gone overboard. If you're on board with the goal of reducing spurious CLI output during install, but think I should rein it in, let me know.
 * I'm not sure how well this plugin works on Windows (if at all) and don't intend to test that myself. Any active Windows/WSL users out there, I'd appreciate your help validating these changes or spotting any obvious issues.
